### PR TITLE
Delete game rooms

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,5 +1,5 @@
 class RoomsController < ApplicationController
-  before_action :set_room, only: %i[edit update]
+  before_action :set_room, only: %i[edit update destroy]
 
   def index
     if params[:search].present? && Room.search(params[:search])
@@ -34,6 +34,13 @@ class RoomsController < ApplicationController
     else
       render :edit
     end
+  end
+
+  def show; end
+
+  def destroy
+    @room.destroy
+    redirect_to home_path, notice: 'Room was successfully deleted.'
   end
 
   private

--- a/app/views/home_page/index.html.haml
+++ b/app/views/home_page/index.html.haml
@@ -10,6 +10,9 @@
     - @rooms.each do |room|
       %li
         = link_to room.name, edit_room_path(room)
+        = link_to "Delete", room_path(room.id), |
+      method: :delete, |
+      data: { confirm: "Are you sure you want to delete #{room.name}?" }
 
 = form_with model: @room, local: true do |f|
   = render partial: 'devise/shared/error_messages', locals: { resource: @room }

--- a/spec/system/delete_game_rooms_spec.rb
+++ b/spec/system/delete_game_rooms_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'DeleteGameRooms', type: :system do
+  include_context 'when user is logged in'
+
+  let(:user) { build(:user, points: 100, rooms: [room]) }
+  let(:room) { create(:room) }
+
+  before do
+    driven_by(:selenium_chrome_headless)
+    visit root_path
+  end
+
+  context 'when deleting a room' do
+    before do
+      click_on 'Delete'
+      page.driver.browser.switch_to.alert.accept
+    end
+
+    it 'displays success message' do
+      expect(page).to have_content('Room was successfully deleted')
+    end
+
+    it 'removes game room from home page' do
+      expect(page).not_to have_content(room.name)
+    end
+  end
+end


### PR DESCRIPTION
Closes #50 

- [x] Adds link to delete room in home page
- [x] Adds show and destroy actions to rooms controller
- [x] Creates spec to ensure deletion of room

Resource: https://medium.com/fusionqa/dealing-with-javascript-alert-from-browser-with-capybara-71bb2428798d
Note: Changed driver from rack test to selenium with headless chrome to execute: ``page.driver.browser.switch_to.alert.accept``